### PR TITLE
Improvements & Bug Fixes

### DIFF
--- a/library/src/lifx/java/android/entities/LFXHSBKColor.java
+++ b/library/src/lifx/java/android/entities/LFXHSBKColor.java
@@ -107,15 +107,17 @@ public class LFXHSBKColor implements Cloneable {
         return newColor;
     }
 
-    public boolean equals(LFXHSBKColor aColor) {
+    @Override
+    public boolean equals(Object aColor) {
         if (aColor == null) {
             return false;
         }
 
-        if (aColor.hue != this.hue ||
-                aColor.saturation != this.saturation ||
-                aColor.brightness != this.brightness ||
-                aColor.kelvin != this.kelvin) {
+
+        if (((LFXHSBKColor)aColor).hue != this.hue ||
+                ((LFXHSBKColor)aColor).saturation != this.saturation ||
+                ((LFXHSBKColor)aColor).brightness != this.brightness ||
+                ((LFXHSBKColor)aColor).kelvin != this.kelvin) {
             return false;
         }
 

--- a/library/src/lifx/java/android/entities/internal/LFXMessage.java
+++ b/library/src/lifx/java/android/entities/internal/LFXMessage.java
@@ -10,6 +10,7 @@ package lifx.java.android.entities.internal;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import lifx.java.android.entities.internal.LFXBinaryTargetID.LFXBinaryTargetType;
 import lifx.java.android.entities.internal.LFXBinaryTargetID.TagField;
@@ -177,6 +178,8 @@ public class LFXMessage {
 
         try {
             payload = messagePayloadClass.getDeclaredConstructor(new Class[]{byte[].class, int.class}).newInstance(data, PAYLOAD_START_INDEX);
+        } catch (NullPointerException e) {
+            LFXLog.e(TAG,"getPayloadFromMessageData() - No implementation for "+messageType.toString());
         } catch (InstantiationException e) {
             e.printStackTrace();
         } catch (IllegalAccessException e) {
@@ -194,7 +197,7 @@ public class LFXMessage {
 
     public static LFXMessage messageWithMessageData(byte[] data) {
         if (data == null || data.length == 0 || getTypeFromMessageData(data) == null) {
-            LFXLog.w(TAG, "Warning: invalid type" + StructleTypes.getShortValue(data[32], data[33]));
+            LFXLog.w(TAG, "Warning: invalid type: " + StructleTypes.getShortValue(data[32], data[33]));
             return null;
         }
 
@@ -416,7 +419,12 @@ public class LFXMessage {
         writeIsAddressableToMessage(true, data);
         writeAtTimeToMessage(atTime, data);
         writeTypeToMessage(messageType, data);
-        writeSiteIDToMessage(path.getSiteID().getDataValue(), data);
+        if(path!=null && path.getSiteID()!=null) {
+            writeSiteIDToMessage(path.getSiteID().getDataValue(), data);
+        }
+        else {
+            LFXLog.e(TAG,"getMessageDataRepresentation() - Message with no path/siteId:"+ Arrays.toString(data));
+        }
 
         if (path.getBinaryTargetID().geTargetType() == LFXBinaryTargetType.DEVICE) {
             writeTargetIDtoMessage(path.getBinaryTargetID().getDeviceDataValue(), data);

--- a/library/src/lifx/java/android/entities/internal/LFXSiteID.java
+++ b/library/src/lifx/java/android/entities/internal/LFXSiteID.java
@@ -64,12 +64,13 @@ public class LFXSiteID {
         return getDebugStringValue();
     }
 
-    public boolean equals(LFXSiteID aSiteID) {
+    @Override
+    public boolean equals(Object aSiteID) {
         if (aSiteID == null) {
             return false;
         }
 
-        if (!LFXByteUtils.areByteArraysEqual(data, aSiteID.data)) {
+        if (!LFXByteUtils.areByteArraysEqual(data, ((LFXSiteID)aSiteID).data)) {
             return false;
         }
 

--- a/library/src/lifx/java/android/entities/internal/structle/LxProtocol.java
+++ b/library/src/lifx/java/android/entities/internal/structle/LxProtocol.java
@@ -76,6 +76,8 @@ public class LxProtocol {
         LX_PROTOCOL_DEVICE_SET_FACTORY_TEST_MODE,                // LX_PROTOCOL_DEVICE_SET_FACTORY_TEST_MODE = 39
         LX_PROTOCOL_DEVICE_DISABLE_FACTORY_TEST_MODE,                // LX_PROTOCOL_DEVICE_DISABLE_FACTORY_TEST_MODE = 40
         LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE,                // LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE = 41
+        LX_PROTOCOL_DEVICE_ECHO_REQUEST,                 // LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE = 58
+        LX_PROTOCOL_DEVICE_ECHO_RESPONSE,                 // LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE = 59
         LX_PROTOCOL_LIGHT_GET,                // LX_PROTOCOL_LIGHT_GET = 101
         LX_PROTOCOL_LIGHT_SET,                // LX_PROTOCOL_LIGHT_SET = 102
         LX_PROTOCOL_LIGHT_SET_WAVEFORM,                // LX_PROTOCOL_LIGHT_SET_WAVEFORM = 103
@@ -198,6 +200,10 @@ public class LxProtocol {
         typeMap.put(40, Type.LX_PROTOCOL_DEVICE_DISABLE_FACTORY_TEST_MODE);
         typeValueMap.put(Type.LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE, 41);
         typeMap.put(41, Type.LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE);
+        typeValueMap.put(Type.LX_PROTOCOL_DEVICE_ECHO_REQUEST, 58);
+        typeMap.put(58, Type.LX_PROTOCOL_DEVICE_ECHO_REQUEST);
+        typeValueMap.put(Type.LX_PROTOCOL_DEVICE_ECHO_RESPONSE, 59);
+        typeMap.put(59, Type.LX_PROTOCOL_DEVICE_ECHO_RESPONSE);
         typeValueMap.put(Type.LX_PROTOCOL_LIGHT_GET, 101);
         typeMap.put(101, Type.LX_PROTOCOL_LIGHT_GET);
         typeValueMap.put(Type.LX_PROTOCOL_LIGHT_SET, 102);
@@ -297,6 +303,8 @@ public class LxProtocol {
         typeClassMap.put(Type.LX_PROTOCOL_DEVICE_SET_FACTORY_TEST_MODE, LxProtocolDevice.SetFactoryTestMode.class);
         typeClassMap.put(Type.LX_PROTOCOL_DEVICE_DISABLE_FACTORY_TEST_MODE, LxProtocolDevice.DisableFactoryTestMode.class);
         typeClassMap.put(Type.LX_PROTOCOL_DEVICE_STATE_FACTORY_TEST_MODE, LxProtocolDevice.StateFactoryTestMode.class);
+        //typeClassMap.put(LX_PROTOCOL_DEVICE_ECHO_REQUEST, null);
+        //typeClassMap.put(LX_PROTOCOL_DEVICE_ECHO_RESPONSE, null);
         typeClassMap.put(Type.LX_PROTOCOL_LIGHT_GET, LxProtocolLight.Get.class);
         typeClassMap.put(Type.LX_PROTOCOL_LIGHT_SET, LxProtocolLight.Set.class);
         typeClassMap.put(Type.LX_PROTOCOL_LIGHT_SET_WAVEFORM, LxProtocolLight.SetWaveform.class);

--- a/library/src/lifx/java/android/light/LFXLight.java
+++ b/library/src/lifx/java/android/light/LFXLight.java
@@ -200,20 +200,23 @@ public class LFXLight extends LFXLightTarget {
     }
 
     public void labelDidChangeTo(String label) {
-        notifyListenerLabelDidChange(label);
-
+        if(this.label==null || !this.label.equals(label)) {
+            notifyListenerLabelDidChange(label);
+        }
         this.label = label;
     }
 
     public void colorDidChangeTo(LFXHSBKColor color) {
-        notifyListenersColorDidChange(color);
-
+        if(this.color==null || !this.color.equals(color)) {
+            notifyListenersColorDidChange(color);
+        }
         this.color = color;
     }
 
     public void powerDidChangeTo(LFXPowerState powerState) {
-        notifyListenersPowerStateDidChange(powerState);
-
+        if(this.powerState==null || !this.powerState.equals(powerState)) {
+            notifyListenersPowerStateDidChange(powerState);
+        }
         this.powerState = powerState;
     }
 

--- a/library/src/lifx/java/android/network_context/internal/routing_table/LFXRoutingTable.java
+++ b/library/src/lifx/java/android/network_context/internal/routing_table/LFXRoutingTable.java
@@ -103,9 +103,13 @@ public class LFXRoutingTable {
     }
 
     public void updateSiteID(LFXSiteID siteID) {
-        if (mutableSiteIDs.contains(siteID)) {
-            return;
+
+        for(LFXSiteID siteTest:mutableSiteIDs) {
+            if(siteTest.equals(siteID)) return;
         }
+//        if (mutableSiteIDs.contains(siteID)) {
+//            return;
+//        }
 
         mutableSiteIDs.add(siteID);
     }
@@ -199,8 +203,7 @@ public class LFXRoutingTable {
         ArrayList<LFXDeviceMapping> deviceMappings = new ArrayList<LFXDeviceMapping>();
 
         for (LFXDeviceMapping aDeviceMapping : mutableDeviceMappingsByDeviceID.values()) {
-            if (aDeviceMapping.getSiteID().equals(siteID) &&
-                    aDeviceMapping.getTagField().equals(tagField)) {
+            if (aDeviceMapping.getSiteID().equals(siteID) && aDeviceMapping.getTagField().equals(tagField)) {
                 deviceMappings.add(aDeviceMapping);
             }
         }

--- a/library/src/lifx/java/android/network_context/internal/routing_table/LFXRoutingTable.java
+++ b/library/src/lifx/java/android/network_context/internal/routing_table/LFXRoutingTable.java
@@ -103,14 +103,9 @@ public class LFXRoutingTable {
     }
 
     public void updateSiteID(LFXSiteID siteID) {
-
-        for(LFXSiteID siteTest:mutableSiteIDs) {
-            if(siteTest.equals(siteID)) return;
+        if (mutableSiteIDs.contains(siteID)) {
+            return;
         }
-//        if (mutableSiteIDs.contains(siteID)) {
-//            return;
-//        }
-
         mutableSiteIDs.add(siteID);
     }
 

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXGatewayConnection.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXGatewayConnection.java
@@ -36,11 +36,6 @@ public abstract class LFXGatewayConnection {
         CONNECTED,
     }
 
-    ;
-
-    public void setListener(LFXGatewayConnectionListener listener) {
-        this.listener = listener;
-    }
 
     public static LFXGatewayConnection getGatewayConnectionWithGatewayDescriptor(LFXGatewayDescriptor gatewayDescriptor, LFXGatewayConnectionListener listener) {
         // TODO: implement TCP
@@ -87,6 +82,10 @@ public abstract class LFXGatewayConnection {
 
     protected LFXGatewayConnectionListener getListener() {
         return listener;
+    }
+
+    public void setListener(LFXGatewayConnectionListener listener) {
+        this.listener = listener;
     }
 
     // To be called externally (subclasses to override)

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXSocketUDP.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXSocketUDP.java
@@ -69,10 +69,16 @@ public class LFXSocketUDP extends LFXSocketGeneric {
                     if (!dataGramSocket.isClosed()) {
                         dataGramSocket.send(udpPacket);
                     }
-                } catch (Exception e) {
+
+                }
+                catch (Exception e) {
                     e.printStackTrace();
                     close();
                 }
+                finally {
+                    dataGramSocket.close();
+                }
+
             }
         }
     }

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXUDPGatewayConnection.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXUDPGatewayConnection.java
@@ -204,7 +204,7 @@ public class LFXUDPGatewayConnection extends LFXGatewayConnection implements Soc
     public void idleTimeoutTimerDidFire() {
         LFXLog.w(TAG, "idleTimeoutTimerDidFire() - Occurred on UDP Connection " + toString() + ", disconnecting");
         setConnectionState(LFXGatewayConnectionState.NOT_CONNECTED);
-        getListener().gatewayConnectionDidDisconnectWithError(this, null);
+        if(getListener()!=null) getListener().gatewayConnectionDidDisconnectWithError(this, null);
     }
 
     private void udpSocketDidReceiveDataFromAddressWithFilterContext(LFXSocketGeneric socket, byte[] data, byte[] address, Object filterContext) {
@@ -254,12 +254,12 @@ public class LFXUDPGatewayConnection extends LFXGatewayConnection implements Soc
 
     public void udpSocketDidCloseWithError(LFXSocketGeneric socket, String error) {
         setConnectionState(LFXGatewayConnectionState.NOT_CONNECTED);
-        getListener().gatewayConnectionDidDisconnectWithError(this, error);
+        if(getListener()!=null) getListener().gatewayConnectionDidDisconnectWithError(this, error);
     }
 
     public void udpSocketDidNotConnect(LFXSocketGeneric socket, String error) {
         setConnectionState(LFXGatewayConnectionState.NOT_CONNECTED);
-        getListener().gatewayConnectionDidDisconnectWithError(this, error);
+        if(getListener()!=null) getListener().gatewayConnectionDidDisconnectWithError(this, error);
     }
 
     @Override
@@ -291,14 +291,14 @@ public class LFXUDPGatewayConnection extends LFXGatewayConnection implements Soc
     public void notifySocketStateChanged(LFXSocketGeneric socket, SocketState state) {
         switch (state) {
             case CONNECTED:
-                getListener().gatewayConnectionDidConnect(this);
+                if(getListener()!=null) getListener().gatewayConnectionDidConnect(this);
                 break;
 
             case CONNECTING:
                 break;
 
             case DISCONNECTED:
-                getListener().gatewayConnectionDidDisconnectWithError(this, "");
+                if(getListener()!=null) getListener().gatewayConnectionDidDisconnectWithError(this, "");
                 break;
         }
     }

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXUDPGatewayConnection.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/gateway_connection/LFXUDPGatewayConnection.java
@@ -92,8 +92,13 @@ public class LFXUDPGatewayConnection extends LFXGatewayConnection implements Soc
         }
 
         if (getConnectionState() == LFXGatewayConnectionState.CONNECTED) {
-            LFXMessage message = LFXMessage.messageWithTypeAndPath(Type.LX_PROTOCOL_DEVICE_GET_PAN_GATEWAY, getGatewayDescriptor().getPath());
-            sendMessage(message);
+            if(getGatewayDescriptor().getPath()!=null) {
+                LFXMessage message = LFXMessage.messageWithTypeAndPath(Type.LX_PROTOCOL_DEVICE_GET_PAN_GATEWAY, getGatewayDescriptor().getPath());
+                sendMessage(message);
+            }
+            else {
+                LFXLog.e(TAG,"heartbeatTimerDidFire() - getGatewayDescriptor().getPath()==null");
+            }
         }
     }
 
@@ -231,8 +236,11 @@ public class LFXUDPGatewayConnection extends LFXGatewayConnection implements Soc
         LFXMessage message = LFXMessage.messageWithMessageData(data);
 
         if (message == null) {
-            LFXLog.e(TAG, "udpSocketDidReceiveDataFromAddressWithFilterContext() - Couldn't create message from data: " + Arrays.toString(data));
+            LFXLog.e(TAG, "udpSocketRx() - Couldn't create message from data: " + Arrays.toString(data));
             return;
+        }
+        else {
+            LFXLog.i(TAG, "udpSocketRx() - Got: "+message.getType().toString());
         }
 
         if (getListener() != null) {

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/lan/LFXLANTransportManager.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/lan/LFXLANTransportManager.java
@@ -107,70 +107,88 @@ public class LFXLANTransportManager extends LFXTransportManager implements LFXGa
     }
 
     public void sendMessage(LFXMessage message) {
-        LFXLog.d(TAG, "sendMessage()");
+        LFXLog.i(TAG, "sendMessage() - "+message.getType().toString());
         if (message.getPath().getSiteID().isZeroSite()) {
             for (String aGatewayHost : getGatewayHosts()) {
-                LFXGatewayConnection tcpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_TCP);
+                //LFXGatewayConnection tcpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_TCP);
                 LFXGatewayConnection udpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_UDP);
 
-                ArrayList<LFXGatewayConnection> connections = new ArrayList<LFXGatewayConnection>();
-
-                if (tcpConnection != null) {
-                    connections.add(tcpConnection);
+                if(udpConnection!=null) {
+                    sendMessageOnConnection(message, udpConnection);
+                }
+                else {
+                    LFXLog.e(TAG,"sendMessage() - No connection?");
                 }
 
-                if (udpConnection != null) {
-                    connections.add(udpConnection);
-                }
 
-                LFXGatewayConnection connectionToUse = null;
+// CAKEY123445 - No TCP Support so removed transport
 
-                if (connections.size() > 0) {
-                    connectionToUse = connections.get(0);
-                }
-
-                if (connectionToUse != null) {
-                    sendMessageOnConnection(message, connectionToUse);
-                }
+//                ArrayList<LFXGatewayConnection> connections = new ArrayList<LFXGatewayConnection>();
+//
+//                if (tcpConnection != null) {
+//                    connections.add(tcpConnection);
+//                }
+//
+//                if (udpConnection != null) {
+//                    connections.add(udpConnection);
+//                }
+//
+//                LFXGatewayConnection connectionToUse = null;
+//
+//                if (connections.size() > 0) {
+//                    connectionToUse = connections.get(0);
+//                }
+//
+//                if (connectionToUse != null) {
+//                    sendMessageOnConnection(message, connectionToUse);
+//                }
             }
-        } else {
+        }
+        else {
             boolean messageWasSent = false;
             for (String aGatewayHost : getGatewayHostsForSiteID(message.getPath().getSiteID())) {
-                LFXGatewayConnection tcpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_TCP);
+                //LFXGatewayConnection tcpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_TCP);
                 LFXGatewayConnection udpConnection = getGatewayConnectionForHost(aGatewayHost, Service.LX_PROTOCOL_DEVICE_SERVICE_UDP);
 
-                ArrayList<LFXGatewayConnection> connections = new ArrayList<LFXGatewayConnection>();
-                if (message.prefersUDPOverTCP()) {
-                    if (udpConnection != null) {
-                        connections.add(udpConnection);
-                    }
-
-                    if (tcpConnection != null) {
-                        connections.add(tcpConnection);
-                    }
-                } else {
-                    if (tcpConnection != null) {
-                        connections.add(tcpConnection);
-                    }
-
-                    if (udpConnection != null) {
-                        connections.add(udpConnection);
-                    }
-                }
-
-                LFXGatewayConnection connectionToUse = null;
-
-                if (connections.size() > 0) {
-                    connectionToUse = connections.get(0);
-                }
-
-                if (connectionToUse != null) {
-                    sendMessageOnConnection(message, connectionToUse);
+                if(udpConnection!=null) {
+                    sendMessageOnConnection(message, udpConnection);
                     messageWasSent = true;
                 }
+
+// CAKEY123445 - No TCP Support so removed transport
+
+//                ArrayList<LFXGatewayConnection> connections = new ArrayList<LFXGatewayConnection>();
+//                if (message.prefersUDPOverTCP()) {
+//                    if (udpConnection != null) {
+//                        connections.add(udpConnection);
+//                    }
+//
+//                    if (tcpConnection != null) {
+//                        connections.add(tcpConnection);
+//                    }
+//                } else {
+//                    if (tcpConnection != null) {
+//                        connections.add(tcpConnection);
+//                    }
+//
+//                    if (udpConnection != null) {
+//                        connections.add(udpConnection);
+//                    }
+//                }
+//
+//                LFXGatewayConnection connectionToUse = null;
+//
+//                if (connections.size() > 0) {
+//                    connectionToUse = connections.get(0);
+//                }
+//
+//                if (connectionToUse != null) {
+//                    sendMessageOnConnection(message, connectionToUse);
+//                    messageWasSent = true;
+//                }
             }
 
-            if (messageWasSent == false) {
+            if (!messageWasSent) {
                 sendMessageOnConnection(message, broadcastUDPConnection);
             }
         }

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/lan/gateway_discovery/LFXGatewayDiscoveryController.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/lan/gateway_discovery/LFXGatewayDiscoveryController.java
@@ -95,6 +95,9 @@ public class LFXGatewayDiscoveryController {
             LFXLog.e(TAG, "handleStatePANGatewayMessage() - TCP Protocol unsupported");
             return;
         }
+        else {
+            LFXLog.i(TAG, "handleStatePANGatewayMessage() - "+service.toString());
+        }
 
         LFXGatewayDescriptor gatewayDescriptor = LFXGatewayDescriptor.getGatewayDescriptorWithHostPortPathService(host, port, path, service);
 

--- a/library/src/lifx/java/android/network_context/internal/transport_manager/lan/gateway_discovery/LFXGatewayDiscoveryController.java
+++ b/library/src/lifx/java/android/network_context/internal/transport_manager/lan/gateway_discovery/LFXGatewayDiscoveryController.java
@@ -35,6 +35,9 @@ public class LFXGatewayDiscoveryController {
 
     private LFXGatewayDiscoveryControllerListener listener;
     private boolean ended = false;
+    private Timer discoveryTimer;
+    private LFXLANTransportManager transportManager;
+    private ArrayList<LFXGatewayDiscoveryTableEntry> table;
 
     // This property will change how often DeviceGetPanGateway messages are broadcast
     private LFXGatewayDiscoveryMode discoveryMode;
@@ -68,11 +71,6 @@ public class LFXGatewayDiscoveryController {
         public void gatewayDiscoveryControllerDidUpdateEntry(LFXGatewayDiscoveryController table, LFXGatewayDiscoveryTableEntry tableEntry, boolean entryIsNew);
     }
 
-    private Timer discoveryTimer;
-
-    private LFXLANTransportManager transportManager;
-    private ArrayList<LFXGatewayDiscoveryTableEntry> table;
-
     @SuppressWarnings({"unchecked", "unused"})
     private ArrayList<LFXGatewayDiscoveryTableEntry> getAllGatewayDiscoveryTableEntries() {
         return (ArrayList<LFXGatewayDiscoveryTableEntry>) table.clone();
@@ -96,7 +94,7 @@ public class LFXGatewayDiscoveryController {
             return;
         }
         else {
-            LFXLog.i(TAG, "handleStatePANGatewayMessage() - "+service.toString());
+            LFXLog.i(TAG, "handleStatePANGatewayMessage() - " + service.toString());
         }
 
         LFXGatewayDescriptor gatewayDescriptor = LFXGatewayDescriptor.getGatewayDescriptorWithHostPortPathService(host, port, path, service);
@@ -146,8 +144,6 @@ public class LFXGatewayDiscoveryController {
     }
 
     public void configureTimerForDiscoveryMode(LFXGatewayDiscoveryMode discoveryMode) {
-        LFXLog.d(TAG, "DISCOVERYMODE: " + discoveryMode);
-
         long duration = 1000;
         switch (discoveryMode) {
             case NORMAL:
@@ -163,7 +159,7 @@ public class LFXGatewayDiscoveryController {
             discoveryTimer.purge();
         }
 
-        LFXLog.d(TAG, "Making Discovery Timer task. Period: " + duration);
+        LFXLog.d(TAG, "configureTimerForDiscoveryMode() - Mode="+discoveryMode+" Timer Period: " + duration);
         discoveryTimer = LFXTimerUtils.getTimerTaskWithPeriod(getDiscoverTimerTask(), duration, false, "DisoveryTimer");
     }
 
@@ -177,8 +173,8 @@ public class LFXGatewayDiscoveryController {
         if (discoveryTimer != null) {
             discoveryTimer.cancel();
             discoveryTimer.purge();
+            discoveryTimer=null;
         }
-
         ended = true;
     }
 }

--- a/library/src/lifx/java/android/util/LFXTimerUtils.java
+++ b/library/src/lifx/java/android/util/LFXTimerUtils.java
@@ -37,7 +37,7 @@ public class LFXTimerUtils {
 //    }
 
     public static Timer getTimerTaskWithPeriod(Runnable task, long period, boolean immediate, String name) {
-        LFXLog.d(TAG, "getTimerTaskWithPeriod() - " + name + ", " + period);
+        //LFXLog.d(TAG, "getTimerTaskWithPeriod() - " + name + ", " + period);
         Timer timer = new Timer();
         long delay = 0L;
 


### PR DESCRIPTION
This PR covers a number of reported issues and other fixes to hopefully make things a little more reliable. It addresses:

LFXUDPGatewayConnection.java - Heartbeat & SendLimit timers now purged & nulled.
Removal of tcp transports from LFXLANTransportManager.sendMessage()
Added constants for message types LX_PROTOCOL_DEVICE_ECHO_REQUEST/LX_PROTOCOL_DEVICE_ECHO_RESPONSE
Added NPE catch for missing implementation of message type
Fix for LIFX#26 - Socket closed
Fix for LIFX#23 - LFXSiteID.equals() updated
Debug messages for sentMessage and receivedMessage - types
Fix to LFXLight.colorDidChange - Now only notifies when colour actually changes
Fix to LFXLight.powerDidChange - Now only notifies when power actually changes
Fix to LFXLight.labelDidChange - Now only notifies when label actually changes
LFXSocketUDP.java - Socket now gets closed
